### PR TITLE
Make CSS Custom Property name prefix (--) configurable as plugin option

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,30 +1,28 @@
 # PostCSS Import JSON
 
-Imports a JSON file and generates CSS custom properties (variables).
+Imports a JSON file and generates [CSS custom properties](https://developer.mozilla.org/en-US/docs/Web/CSS/Using_CSS_custom_properties).
 
 ## Usage
 
 Install plugin.
 
-```
+```sh
 npm i -D @daltontan/postcss-import-json
 ```
 
 Add to you PostCSS config:
 
-```
+```javascript
 module.exports = {
-	plugins: [
-		require('@daltontan/postcss-import-json'),
-	]
-}
+  plugins: [require("@daltontan/postcss-import-json")],
+};
 ```
 
 Add to your CSS file:
 
-```
+```css
 :root {
-	@import-json './path/to.json';
+  @import-json './path/to.json';
 }
 ```
 
@@ -36,32 +34,59 @@ The path is relative to the CSS file.
 
 A function to convert the variable values. For example:
 
-```
+```javascript
 @param {string[]} selector - The keys that form the current value e.g. {parent: {child: 'value'}} will have the child
 selector as ['parent', 'child'].
 @param value - The value for the current node.
 (selector, value) => selector[0] === 'color' ? '#' + value : value
+```
 
+### prefix
+
+The CSS Custom properties prefix, default is `--`.
+
+JSON input:
+
+```json
+{
+  "my-color": "red"
+}
+```
+
+```javascript
+module.exports = {
+  plugins: [
+    require("@daltontan/postcss-import-json"), // :root { --my-color: red; } (default)
+  ],
+};
+
+module.exports = {
+  plugins: [
+    require("@daltontan/postcss-import-json", {
+      prefix: "", // :root { my-color: red; }
+    }),
+  ],
+};
 ```
 
 # Example
 
 JSON input:
 
-```
+```json
 {
-	"pageWidth": 800,
-	"color": {
-		"primary": "#00f",
-		"secondary": "#0aa"
-	},
-	"border-radius": "1rem"
+  "pageWidth": 800,
+  "color": {
+    "primary": "#00f",
+    "secondary": "#0aa"
+  },
+  "border-radius": "1rem"
 }
 ```
 
 Generated CSS:
 
-```
+```css
 --pageWidth: 800;
 --color-primary: #00f;
 --color-secondary: #0aa;

--- a/index.js
+++ b/index.js
@@ -15,17 +15,17 @@ module.exports.postcss = true
 function plugin(opts, placeholder, src, { Declaration }) {
 	src = path.join(path.dirname(placeholder.source.input.file), src)
 	const vars = require(src)
-	for (const decl of walk(vars, [], Declaration, opts.map)) {
+	for (const decl of walk(vars, [], Declaration, opts)) {
 		placeholder.after(decl)
 	}
 	placeholder.remove()
 }
 
-function walk(tree, selectors, Declaration, map) {
+function walk(tree, selectors, Declaration, { prefix = '--', map }) {
 	let output = []
 	for (const key in tree) {
 		const s = [...selectors, key]
-		const name = '--' + s.join('-')
+		const name = prefix + s.join('-')
 		let v = tree[key]
 		if (map) {
 			v = map(s, v)


### PR DESCRIPTION
First off, thanks for making this plugin!


I would like to propose a suggestion to make this plugin more usable.

**Situation/why**

I have a postcss custom properties JSON export, generated with the [exportTo](https://github.com/postcss/postcss-custom-properties#exportto) option. I then want to import this JSON object in my CSS inside a `:host {...}` selector.

Example

```
styles.css

:host {
  @import-json 'custom-properties.json';
}
```

I think postcss-import-json is the perfect solution for this.

But there is one catch:

The postcss custom properties JSON export name are equal to the custom properties names.

example

```json
custom-properties.json

{
  "custom-properties": {
    "--color": "red"
  }
}
```

But postcss-import-json then also add's the custom properties `--` prefix by default, see https://github.com/AgentCosmic/postcss-import-json/blob/master/index.js#L28.

**Suggestion/fix**

My suggestion would be to make adding of the custom properties `--` prefix optional.
By default is it true but can also be turned off by setting it to 'false' (or replace with a custom 'string' based prefix).

```javavascript
postcss.config.js

module.exports = {
  plugins: [
    postcssImportJson({
      customPropertyPrefix: false
    })
  ]
};
```

I have made a PR with my suggestion.

What do you think?


Greetings,

Wouter